### PR TITLE
feat: add authentication and family files for specifying custom target and source wikis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,7 @@ WORKDIR /usr/src/pywikibot
 RUN pip install --no-cache-dir -r requirements.txt && \
     pip install --no-cache-dir .
 
+RUN mkdir -p families
+COPY source_family.py target_family.py ./families
+
 ENTRYPOINT ["pwb", "scripts/transferbot.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,6 @@ RUN pip install --no-cache-dir -r requirements.txt && \
 
 RUN mkdir -p families
 COPY source_family.py target_family.py ./families
+COPY user-config.py .
 
 ENTRYPOINT ["pwb", "scripts/transferbot.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,7 @@ WORKDIR /usr/src/pywikibot
 RUN pip install --no-cache-dir -r requirements.txt && \
     pip install --no-cache-dir .
 
-RUN mkdir -p families
-COPY source_family.py target_family.py ./families
+COPY source_family.py target_family.py ./families/
 COPY user-config.py .
 
 ENTRYPOINT ["pwb", "scripts/transferbot.py"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
 # Transferbot
+
+## Configuration
+
+Configuration is provided using the following environment variables:
+
+### `SOURCE_WIKI_HOSTNAME`
+
+The hostname of the source wiki, e.g. `coffeebase.wikibase.cloud`
+
+### `SOURCE_WIKI_PROTOCOL`
+
+The protocol used by the source wiki, defaults to `HTTPS`
+
+### `TARGET_WIKI_HOSTNAME`
+
+The hostname of the target wiki, e.g. `newwiki.wikibase.cloud`
+
+### `TARGET_WIKI_PROTOCOL`
+
+The protocol used by the target wiki, defaults to `HTTPS`
+
+### `TARGET_WIKI_CONSUMER_TOKEN`
+
+The OAuth consumer token used for authenticating against the target wiki.
+
+### `TARGET_WIKI_CONSUMER_SECRET`
+
+The OAuth consumer secret used for authenticating against the target wiki.
+
+### `TARGET_WIKI_ACCESS_TOKEN`
+
+The OAuth access token used for authenticating against the target wiki.
+
+### `TARGET_WIKI_ACCESS_SECRET`
+
+The OAuth access secret used for authenticating against the target wiki.

--- a/source_family.py
+++ b/source_family.py
@@ -1,0 +1,13 @@
+from os import environ
+
+from pywikibot import family
+
+class Family(family.Family):
+    name = 'source'
+
+    langs = {
+        'en': None,
+    }
+
+    def hostname(self, code):
+        return environ.get('SOURCE_WIKI_HOSTNAME')

--- a/source_family.py
+++ b/source_family.py
@@ -2,7 +2,7 @@ from os import environ
 
 from pywikibot import family
 
-class Family(family.Family):
+class Family(family.WikibaseFamily):
     name = 'source'
 
     langs = {
@@ -11,3 +11,6 @@ class Family(family.Family):
 
     def hostname(self, code):
         return environ.get('SOURCE_WIKI_HOSTNAME')
+
+    def protocol(self, code):
+        return environ.get('SOURCE_WIKI_PROTOCOL', 'HTTPS')

--- a/target_family.py
+++ b/target_family.py
@@ -1,0 +1,13 @@
+from os import environ
+
+from pywikibot import family
+
+class Family(family.Family):
+    name = 'target'
+
+    langs = {
+        'en': None,
+    }
+
+    def hostname(self, code):
+        return environ.get('TARGET_WIKI_HOSTNAME')

--- a/target_family.py
+++ b/target_family.py
@@ -2,7 +2,7 @@ from os import environ
 
 from pywikibot import family
 
-class Family(family.Family):
+class Family(family.WikibaseFamily):
     name = 'target'
 
     langs = {
@@ -11,3 +11,6 @@ class Family(family.Family):
 
     def hostname(self, code):
         return environ.get('TARGET_WIKI_HOSTNAME')
+
+    def protocol(self, code):
+        return environ.get('TARGET_WIKI_PROTOCOL', 'HTTPS')

--- a/user-config.py
+++ b/user-config.py
@@ -1,0 +1,8 @@
+from os import environ
+
+authenticate[environ.get('TARGET_WIKI_HOSTNAME')] = (
+    environ.get('TARGET_WIKI_CONSUMER_TOKEN'),
+    environ.get('TARGET_WIKI_CONSUMER_SECRET'),
+    environ.get('TARGET_WIKI_ACCESS_TOKEN'),
+    environ.get('TARGET_WIKI_ACCESS_SECRET'),
+)


### PR DESCRIPTION
This allows users to set `SOURCE_WIKI_HOSTNAME` and `TARGET_WIKI_HOSTNAME` which then allows us to specify `target` and `source` families when invoking `pwb`.