### PR TITLE
fix: fix username target

### DIFF
--- a/user-config.py
+++ b/user-config.py
@@ -1,5 +1,4 @@
 from os import environ
-from pywikibot import family
 
 authenticate[environ.get('TARGET_WIKI_HOSTNAME')] = (
     environ.get('TARGET_WIKI_CONSUMER_TOKEN'),
@@ -8,4 +7,4 @@ authenticate[environ.get('TARGET_WIKI_HOSTNAME')] = (
     environ.get('TARGET_WIKI_ACCESS_SECRET'),
 )
 
-usernames[family.Family("target")]['en'] = environ.get('TARGET_WIKI_USER')
+usernames['target']['en'] = environ.get('TARGET_WIKI_USER')


### PR DESCRIPTION
It seems the code in the error message is outdated and this needs to be a string.