### PR TITLE
feat: make this a generic pywikibot image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/src
 RUN apt-get update && \
     apt-get install --no-install-recommends -y git=1:2.39.2-1.1 && \
     rm -rf /var/lib/apt/lists/*
-RUN git clone --depth 1 --branch 8.5.1 https://github.com/wikimedia/pywikibot
+RUN git clone --recursive --depth 1 --branch 8.5.1 https://github.com/wikimedia/pywikibot
 
 WORKDIR /usr/src/pywikibot
 
@@ -15,4 +15,4 @@ RUN pip install --no-cache-dir -r requirements.txt && \
 COPY source_family.py target_family.py ./families/
 COPY user-config.py .
 
-ENTRYPOINT ["pwb", "scripts/transferbot.py"]
+ENTRYPOINT ["/usr/src/pywikibot/pwb.py"]

--- a/README.md
+++ b/README.md
@@ -1,37 +1,69 @@
-# Transferbot
+# pywikibot
+
+A Docker image providing `pywikibot` with a Wikibase.cloud specific families, configured using environment variables.
 
 ## Configuration
 
 Configuration is provided using the following environment variables:
 
+---
+
 ### `SOURCE_WIKI_HOSTNAME`
 
 The hostname of the source wiki, e.g. `coffeebase.wikibase.cloud`
 
-### `SOURCE_WIKI_PROTOCOL`
+### `SOURCE_WIKI_PROTOCOL` (optional)
 
 The protocol used by the source wiki, defaults to `HTTPS`
+
+### `SOURCE_WIKI_USERNAME` (optional)
+
+The username tied to the OAuth 1.0 credentials.
+In case this is not provided, access to the source wiki will be unauthenticated.
+
+### `SOURCE_WIKI_CONSUMER_TOKEN` (optional)
+
+The OAuth consumer token used for authenticating against the source wiki.
+
+### `SOURCE_WIKI_CONSUMER_SECRET` (optional)
+
+The OAuth consumer secret used for authenticating against the source wiki.
+
+### `SOURCE_WIKI_ACCESS_TOKEN` (optional)
+
+The OAuth access token used for authenticating against the source wiki.
+
+### `SOURCE_WIKI_ACCESS_SECRET` (optional)
+
+The OAuth access secret used for authenticating against the source wiki.
+
+---
 
 ### `TARGET_WIKI_HOSTNAME`
 
 The hostname of the target wiki, e.g. `newwiki.wikibase.cloud`
 
-### `TARGET_WIKI_PROTOCOL`
+### `TARGET_WIKI_PROTOCOL` (optional)
 
 The protocol used by the target wiki, defaults to `HTTPS`
 
-### `TARGET_WIKI_CONSUMER_TOKEN`
+### `TARGET_WIKI_USERNAME` (optional)
+
+The username tied to the OAuth 1.0 credentials.
+In case this is not provided, access to the source wiki will be unauthenticated.
+
+### `TARGET_WIKI_CONSUMER_TOKEN` (optional)
 
 The OAuth consumer token used for authenticating against the target wiki.
 
-### `TARGET_WIKI_CONSUMER_SECRET`
+### `TARGET_WIKI_CONSUMER_SECRET` (optional)
 
 The OAuth consumer secret used for authenticating against the target wiki.
 
-### `TARGET_WIKI_ACCESS_TOKEN`
+### `TARGET_WIKI_ACCESS_TOKEN` (optional)
 
 The OAuth access token used for authenticating against the target wiki.
 
-### `TARGET_WIKI_ACCESS_SECRET`
+### `TARGET_WIKI_ACCESS_SECRET` (optional)
 
 The OAuth access secret used for authenticating against the target wiki.

--- a/user-config.py
+++ b/user-config.py
@@ -1,10 +1,19 @@
 from os import environ
 
-authenticate[environ.get('TARGET_WIKI_HOSTNAME')] = (
-    environ.get('TARGET_WIKI_CONSUMER_TOKEN'),
-    environ.get('TARGET_WIKI_CONSUMER_SECRET'),
-    environ.get('TARGET_WIKI_ACCESS_TOKEN'),
-    environ.get('TARGET_WIKI_ACCESS_SECRET'),
-)
+if environ.get('TARGET_WIKI_USERNAME'):
+    authenticate[environ.get('TARGET_WIKI_HOSTNAME')] = (
+        environ.get('TARGET_WIKI_CONSUMER_TOKEN'),
+        environ.get('TARGET_WIKI_CONSUMER_SECRET'),
+        environ.get('TARGET_WIKI_ACCESS_TOKEN'),
+        environ.get('TARGET_WIKI_ACCESS_SECRET'),
+    )
+    usernames['target']['en'] = environ.get('TARGET_WIKI_USERNAME')
 
-usernames['target']['en'] = environ.get('TARGET_WIKI_USER')
+if environ.get('SOURCE_WIKI_USERNAME'):
+    authenticate[environ.get('SOURCE_WIKI_HOSTNAME')] = (
+        environ.get('SOURCE_WIKI_CONSUMER_TOKEN'),
+        environ.get('SOURCE_WIKI_CONSUMER_SECRET'),
+        environ.get('SOURCE_WIKI_ACCESS_TOKEN'),
+        environ.get('SOURCE_WIKI_ACCESS_SECRET'),
+    )
+    usernames['source']['en'] = environ.get('SOURCE_WIKI_USERNAME')


### PR DESCRIPTION
As the idea of using the `transferbot` image failed, make this a generic `pywikibot` image.