### PR TITLE
chore: wikibase-cli is outdated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20-alpine
 
 RUN apk add --no-cache jq=1.7.1-r0 curl=8.8.0-r0 && \
-	npm install -g wikibase-cli@17.0.8
+	npm install -g wikibase-cli@18.0.3
 
 COPY --chmod=755 ./transferbot.sh /usr/bin/transferbot
 


### PR DESCRIPTION
To ensure the failures we see when importing from Wikidata are not caused by us running an outdated version, update the version of the CLI tool to the latest version as of now.

According to the [CHANGELOG](https://github.com/maxlath/wikibase-cli/blob/main/CHANGELOG.md), the only breaking change from 17 to 18 is dropping support for Node 16, so we shouldn't be affected by any breakage.