### PR TITLE
feat: allow fetching certain entities at a specific revision id

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:20-alpine
 
-RUN apk add --no-cache curl=8.8.0-r0 python3=3.12.3-r1 && \
+RUN apk add --no-cache curl=8.9.0-r0 python3=3.12.3-r1 && \
 	npm install -g wikibase-cli@18.0.3
 
 COPY --chmod=755 ./transferbot.sh /usr/bin/transferbot

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Positional arguments to be passed are:
 2. The origin of the target wiki
 3. (variadic) A whitespace separated list of entities to be transferred
 
+### Specifying entity ids
+
+An entity ID can be given in the format `Q1`, which looks up the latest revision.
+If you append a revision ID using `@` like `Q1@123`, the given revision ID will be used for this entity.
+
 ---
 
 ## Providing credentials

--- a/transferbot.sh
+++ b/transferbot.sh
@@ -36,6 +36,24 @@ cat <<CREDS
 CREDS
 } > $(wb config path)
 
-wb data $@ --instance "$source_wiki_origin" |\
+read_entities() {
+  # entities are passed as either
+  # "Q42" which fetches the latest revision
+  # "Q42@123" which fetches revision 123
+  for entity in $@; do
+    case $entity in
+      *@*)
+        revision=$(echo $entity | cut -d "@" -f 2)
+        id=$(echo $entity | cut -d "@" -f 1)
+        wb data "$id" --revision "$revision" --instance "$source_wiki_origin"
+      ;;
+      *)
+        wb data "$entity" --instance "$source_wiki_origin"
+      ;;
+    esac
+  done
+}
+
+read_entities $@ |\
   mangle_data -t "$target_wiki_origin" -p type -p labels -p descriptions -p aliases -p datatype |\
   wb create-entity --batch --instance "$target_wiki_origin"


### PR DESCRIPTION
This allows users to pass an optional revid for each entity, locking the imported data to a fixed point in time.

In our setup this is required to fetch data from wikidata like it was before the introduction of the `mul` langiuage code.